### PR TITLE
Delay function split to connect module

### DIFF
--- a/delay.js
+++ b/delay.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = function(delay, f){
+  if(typeof f !== 'number') f = 0;
+  return function(req, res, next){
+    setTimeout(next, (delay + ((Math.random() * f) | 0)) * 1000);
+  };
+};

--- a/server.js
+++ b/server.js
@@ -1,17 +1,12 @@
-var app = require("express")();
-var http = require("http").Server(app);
+'use strict';
 
-app.get("/healthcheck", function(req, res) {
-    setTimeout(
-        () => {
-            res.json({
-                status: 'ok'
-            });
-        },
-        10000
-    );
+const app = require("express")()
+    , delay = require('./delay');
+
+app.get("/healthcheck", delay(10), function(req, res) {
+    res.json({ status: 'ok' });
 });
 
-http.listen(3000, function() {
+app.listen(3000, function() {
     console.log("listening on *:3000");
 });


### PR DESCRIPTION
# Connect Moduleで遅延部分を切り出してみた感じ

setTimeoutで遅延させる部分をConnect Module化するとそれなりにおしゃれ風に見えるんじゃないですかね。

とおもって、ちょっとやってみました、

## Delay Module

### Usage

Add delay to specific endpoint(s)
```javascript
const Delay = require('delay');
// send 'ok' response after 10 seconds.
app.get('/endpoint1', Delay(10), (req, res) => res.send('ok'));
// send 'ok' response after 10~20 seconds.
app.get('/endpoint2', Delay(10, 10), (req, res) => res.send('ok'));
```

Add delay to all endpoints.
```javascript
const Delay = require('delay');
// send response after 10 seconds
app.use(Delay(10));
app.get('/endpoint', (req, res) => res.send('ok');
```

### man

- Delay(seconds[, additional])

Delay response with `seconds` + 0 to `additional` seconds.